### PR TITLE
disable debian frontend when the user calls install_deps.sh

### DIFF
--- a/install_deps.sh
+++ b/install_deps.sh
@@ -27,6 +27,7 @@ install_llvm() {
 	sudo ./llvm.sh 17
 }
 
+export DEBIAN_FRONTEND=noninteractive
 
 sudo apt update -y
 sudo apt install -y wget build-essential cmake python3-dev python3-numpy libprotobuf-dev protobuf-compiler


### PR DESCRIPTION
See description in this ticket: https://trello.com/c/sXvE4POd/34-disable-annoying-debian-front-end-when-the-user-runs-installdepssh
