### PR TITLE
add argument to run method to allow running from a service

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -80,4 +80,4 @@ if __name__ == "__main__":
     threading.Thread(target=connect_to_cpp_server, daemon=True).start()
 
     # Run Flask-SocketIO app
-    socketio.run(app, debug=True, host="0.0.0.0", port=5000)
+    socketio.run(app, debug=True, host="0.0.0.0", port=5000, allow_unsafe_werkzeug=True)


### PR DESCRIPTION
the utility was crashing when Crystal was trying to run it as a service.  Add the "allow_unsafe" argument to workaround this issue until we can fix it for real.