### PR TITLE
Installer Submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "AprilTagsInstall"]
+	path = AprilTagsInstall
+	url = https://github.com/cwosw/AprilTagsInstall.git


### PR DESCRIPTION
Added the AprilTagsInstaller as a submodule named AprilTagsInstaller, to make installation of the AprilTags easier