### PR TITLE
fix compile error

### DIFF
--- a/src/NetworkTablesConfig.h
+++ b/src/NetworkTablesConfig.h
@@ -1,4 +1,7 @@
-#include <string>
+#ifndef NETWORK_TABLES_CONFIG_H_
+#define NETWORK_TABLES_CONFIG_H_
 
-const std::string TABLE_ADDRESS = "10.7.66.2";
-const std::string TABLE_NAME = "/SmartDashboard";
+inline const char* TABLE_ADDRESS = "10.7.66.2";
+inline const char* TABLE_NAME = "/SmartDashboard";
+
+#endif


### PR DESCRIPTION
NetworkTablesConfig.h had a couple of problems:

- no #ifndef directive at the top of the file
- wrong type defined for strings, NetworkTables classes were expecting `const char*` instead of std::string.  I could have fixed this by adding a `.c_str()` to each instance were they were used but this was faster
- needed `inline` added in the definition to avoid multiple declaration linker errors
